### PR TITLE
Update wwDotnetBridge.PRG Added support for handling empty date and d…

### DIFF
--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -1225,7 +1225,7 @@ ENDFUNC
 ***                          the data
 ***    Return: DataSet or NULL
 ************************************************************************
-FUNCTION CursorToDataSet(lcAliasList)
+FUNCTION CursorToDataSet(lcAliasList,fixemptydates)
 LOCAL lnX, lcXml
 
 IF EMPTY(lcAliasList)
@@ -1251,6 +1251,20 @@ loAdapter.ToXML("lcXml")
 
 IF EMPTY(lcXml)
    RETURN null
+ENDIF
+
+IF fixemptydates
+* add nillable=true to xds part of xml for date and Datetime fileds
+lcXml= STRTRAN(lcXml,'type="xsd:date"' ,'type="xsd:date" nillable="true"') && dates
+lcXml= STRTRAN(lcXml,'type="xsd:dateTime"' ,'type="xsd:dateTime" nillable="true"') &&dateTime
+*delete all self closeing <fName/> tags for date fileds from the xml
+FOR lnX = 1 TO lnCount && loop lcAliasList
+FOR Lnxfldloop = 1 TO AFIELDS(afldsarr,laCursors[lnX]) && loop Fields
+IF INLIST(afldsarr(Lnxfldloop ,2),"D","T")
+lcXml= STRTRAN(lcXml,   '<'+LOWER(afldsarr(Lnxfldloop ,1) )+'/>'  ,'')
+endif
+endfor
+ENDFOR
 ENDIF
 
 RETURN THIS.XmlStringToDataSet(lcXml)   


### PR DESCRIPTION
Handle Empty date/datetime Fields in CursorToDataSet
This update adds support for handling empty date and datetime fields in the CursorToDataSet function.

Previously, I encountered issues when working with Visual FoxPro cursors that included empty date fields—.NET would fail to accept them during DataSet.ReadXml() processing. This change resolves that issue.

Key changes:

Introduced an optional parameter to enable handling of empty date/datetime fields.

If enabled, the generated XSD will include nillable="true" for date fields.

Empty date/datetime tags are removed from the XML to avoid .NET parsing errors.

This approach maintains backward compatibility while providing a clean solution for working with VFP cursors in .NET.

Also, this is my first-ever pull request on GitHub—so I hope I’m doing it right! Feedback is very welcome.