### PR TITLE
Specify path to DLLs

### DIFF
--- a/ClrHost/CoreClrHost.cpp
+++ b/ClrHost/CoreClrHost.cpp
@@ -23,6 +23,7 @@
 #include <atlbase.h>
 #include <atlcomcli.h>
 #include <MSCorEE.h>
+#include <windows.h>
 
 #define WINDOWS TRUE;
 
@@ -178,12 +179,24 @@ BOOL CoreClrLoad(char* runtimePath, char* errorMessage, DWORD* size)
 		GetCurrentDirectory(MAX_PATH, (LPSTR)curDir);
 
 		std::string appPaths(curDir);
-
 		appPaths.append(PATH_DELIMITER);
 		appPaths.append((const char *)curDir);
 		appPaths.append(FS_SEPARATOR);
 		appPaths.append("bin");
 
+
+		// Add the directory of the executing DLL
+		char dllPath[MAX_PATH];
+		HMODULE hModule = NULL;
+		GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)&CoreClrLoad, &hModule);
+		GetModuleFileNameA(hModule, dllPath, MAX_PATH);
+		std::string dllDir(dllPath);
+		size_t const lastSlash = dllDir.rfind('\\');
+		if (lastSlash != std::string::npos) {
+			dllDir = dllDir.substr(0, lastSlash);
+			appPaths.append(PATH_DELIMITER);
+			appPaths.append(dllDir);
+		}
 
 		const char* propertyValues[] = {
 			tpaList.c_str(),

--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -5,8 +5,9 @@ SET PROCEDURE TO wwDotnetBridge ADDITIVE
 #DEFINE IS_WESTWIND			.F.
 #DEFINE IS_LEGACY 	   		.T.
 
+PUBLIC WWC_CLR_HOSTDLL
 #IF IS_WESTWIND
-	#DEFINE WWC_CLR_HOSTDLL wwipstuff.dll 
+	WWC_CLR_HOSTDLL="wwipstuff.dll"
 
 	*** Other dependencies
 	* .NET Runtime 4.0+ or .NET Core 5+
@@ -16,7 +17,7 @@ SET PROCEDURE TO wwDotnetBridge ADDITIVE
 	* wwDotnetBridge.dll
 	* NewtonSoft.Json.dll - ToJson()/FromJson() only
 #ELSE
-	#DEFINE WWC_CLR_HOSTDLL clrhost.dll
+	WWC_CLR_HOSTDLL="clrhost.dll"
 
 	*** Other dependencies
 	* .NET Runtime 4.0+ or .NET Core 5+
@@ -195,7 +196,7 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 		#ENDIF
 		
 		*** Load by filename - assumes the wwDotNetBridge.dll is in the Fox path
-	   	DECLARE Integer ClrCreateInstanceFrom IN WWC_CLR_HOSTDLL string, string, string@, integer@
+	   	DECLARE Integer ClrCreateInstanceFrom IN (m.WWC_CLR_HOSTDLL) string, string, string@, integer@
 		lcError = SPACE(2048)
 		lnSize = 0
 		lnDispHandle = ClrCreateInstanceFrom(FULLPATH("wwDotNetBridge.dll"),;
@@ -241,7 +242,7 @@ ENDFUNC
 ***    Return: nothing
 ************************************************************************
 PROTECTED FUNCTION SetClrVersion(lcVersion)
-DECLARE Integer SetClrVersion IN WWC_CLR_HOSTDLL AS SetClrVersionApi string
+DECLARE Integer SetClrVersion IN (m.WWC_CLR_HOSTDLL) AS SetClrVersionApi string
 SetClrVersionApi(lcVersion)
 ENDFUNC
 *   SetClrVersion
@@ -259,7 +260,7 @@ ENDFUNC
 FUNCTION Unload()
 IF VARTYPE(this.oDotNetBridge) == "O"
 	this.oDotNetBridge = NULL	
-	DECLARE Integer ClrUnload IN WWC_CLR_HOSTDLL	
+	DECLARE Integer ClrUnload IN (m.WWC_CLR_HOSTDLL)	
 	ClrUnload()
 ENDIF
 ENDFUNC
@@ -1402,7 +1403,7 @@ ENDFUNC
 *!*	FUNCTION CreateClrInstance(lcLibrary,lcClass,lcError)
 *!*	LOCAL lnDispHandle, lnSize
 
-*!*	DECLARE Integer ClrCreateInstance IN WWC_CLR_HOSTDLL string, string, string@, integer@
+*!*	DECLARE Integer ClrCreateInstance IN (m.WWC_CLR_HOSTDLL) string, string, string@, integer@
 
 *!*	lcError = SPACE(2048)
 *!*	lnSize = 0
@@ -1975,7 +1976,7 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 		ENDIF
 			
 		*** Load by filename - assumes the wwDotNetBridge.dll is in the Fox path
-	   	DECLARE Integer CoreClrCreateInstanceFrom IN WWC_CLR_HOSTDLL string, string, string@, integer@
+	   	DECLARE Integer CoreClrCreateInstanceFrom IN (m.WWC_CLR_HOSTDLL) string, string, string@, integer@
 		lcError = SPACE(2048)
 		lnSize = LEN(lcError)
 		lnDispHandle = CoreClrCreateInstanceFrom(lcRuntimePath,lcVersion,@lcError,@lnSize)
@@ -2023,7 +2024,7 @@ ENDFUNC
 FUNCTION Unload()
 IF VARTYPE(this.oDotNetBridge) == "O"
 	this.oDotNetBridge = NULL	
-	DECLARE Integer CoreClrUnload IN WWC_CLR_HOSTDLL	
+	DECLARE Integer CoreClrUnload IN (m.WWC_CLR_HOSTDLL)	
 	CoreClrUnload()
 ENDIF
 ENDFUNC


### PR DESCRIPTION
Makes `WWC_CLR_HOSTDLL` a public variable that the calling app can set to specify where to find `ClrHost.dll` and `wwDotNetBridge.dll`. For example:

``` FoxPro
DO wwDotnetBridge
WWC_CLR_HOSTDLL = "path\to\ClrHost.dll"
InitializeDotnetCoreVersion("9")
* ...
```

To allow the specified path in `WWC_CLR_HOSTDLL` to also work for `wwDotNetBridge.dll`, this PR modifies `ClrHost` to include the directory of `ClrHost.dll` in the .NET DLL path, which applies to finding `wwDotNetBridge.dll` and any other .NET DLLs.