### PR TITLE
Fix event subscriptions for certain parameter types on .NET 9

### DIFF
--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -1838,34 +1838,25 @@ this.oBridge.InvokeMethodAsync(this,this.oSubscriber,"WaitForEvent")
 ENDFUNC
 
 ************************************************************************
-*  OnComplete
+*  OnCompleted
 ****************************************
 ***  Function: Event Proxy that forwards the event to a function 
 ***            named On{Event} with event's parameters.
 ************************************************************************
 FUNCTION OnCompleted(lvResult, lcMethod)
-LOCAL loParams,lParamText,lCount
+LOCAL lParamText, lCount
 
-IF ISNULL(lvResult) && If the call to WaitForEvent was canceled:
+IF ISNULL(lvResult) OR VARTYPE(THIS.oHandler) != "O" && If the call to WaitForEvent was canceled or the handler was unsubscribed:
 	RETURN
 ENDIF
 
-
-loParams=CREATEOBJECT("EMPTY") && Workaround to index into array of parameters. 
 lParamText = ""
-IF NOT ISNULL(lvResult.Params)
-	lCount = 0
-	FOR EACH lParam IN lvResult.Params
-		lCount = lCount + 1
-		AddProperty(loParams,"P" + ALLTRIM(STR(lCount)),lParam)
-		lParamText = lParamText + ",loParams.P" + ALLTRIM(STR(lCount))
-	ENDFOR
-ENDIF
+FOR lCount = 0 TO lvResult.Params.Count - 1
+	lParamText = lParamText + ",lvResult.Params.Item(" + ALLTRIM(STR(lCount)) + ")"
+ENDFOR
 
-IF VARTYPE(THIS.oHandler) = "O"
-	=EVALUATE("this.oHandler." + this.oPrefix + lvResult.Name + "("+SUBSTR(lParamText,2)+")")
-	this.HandleNextEvent()
-ENDIF
+=EVALUATE("this.oHandler." + this.oPrefix + lvResult.Name + "("+SUBSTR(lParamText,2)+")")
+this.HandleNextEvent()
 
 ENDFUNC
 

--- a/DotnetBridge/Utilities/EventSubscriber.cs
+++ b/DotnetBridge/Utilities/EventSubscriber.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,7 +70,9 @@ namespace Westwind.WebConnection
 
         private void QueueInteropEvent(string name, object[] parameters)
         {
-            var interopEvent = new RaisedEvent { Name = name, Params = parameters };
+            var parametersArrayList = new ArrayList(parameters.Length);
+            parametersArrayList.AddRange(parameters);
+            var interopEvent = new RaisedEvent { Name = name, Params = parametersArrayList };
             if (!_completion.TrySetResult(interopEvent))
                 _raisedEvents.Enqueue(interopEvent);
         }
@@ -93,6 +96,6 @@ namespace Westwind.WebConnection
     public class RaisedEvent
     {
         public string Name { get; internal set; }
-        public object[] Params { get; internal set; }
+        public ArrayList Params { get; internal set; }
     }
 }

--- a/Tests/EventSubscriberTests.cs
+++ b/Tests/EventSubscriberTests.cs
@@ -35,9 +35,9 @@ namespace wwDotnetBridge.Tests
         static void VerifyResults(EventSubscriber subscriber)
         {
             var result = subscriber.WaitForEvent();
-            Assert.IsTrue(result.Name == nameof(Loopback.NoParams) && result.Params.Length == 0);
+            Assert.IsTrue(result.Name == nameof(Loopback.NoParams) && result.Params.Count == 0);
             result = subscriber.WaitForEvent();
-            Assert.IsTrue(result.Name == nameof(Loopback.TwoParams) && result.Params.Length == 2 && (string)result.Params[0] == "A" && (int)result.Params[1] == 1);
+            Assert.IsTrue(result.Name == nameof(Loopback.TwoParams) && result.Params.Count == 2 && (string)result.Params[0] == "A" && (int)result.Params[1] == 1);
         }
     }
 


### PR DESCRIPTION
For .NET 9 (and perhap earlier versions), events from `SubscribeToEvents` passed incorrect parameters. For example, a null string was becoming a quotation mark. To fix it, I replaced the existing array marshalling workaround with an `ArrayList`. It's also less code and probably faster.