### PR TITLE
Remove target-conditional properties

### DIFF
--- a/DotnetBridge/wwDotNetBridge.csproj
+++ b/DotnetBridge/wwDotNetBridge.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<!-- Compatible with .NET 4.72 through .NET 9 (and possibly later). Targets just net472 so that a single DLL can be used with all frameworks. -->
 		<TargetFramework>net472</TargetFramework>
 		<Version>8.1.4</Version>
 		<Authors>Rick Strahl</Authors>
@@ -29,17 +30,10 @@
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DebugType>embedded</DebugType>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' != 'net472'">
-		<DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
-		<DefineConstants>NETFULL</DefineConstants>
+
 	</PropertyGroup>
 
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+	<ItemGroup>
 		<Reference Include="mscorlib" />
 		<Reference Include="System" />
 		<Reference Include="System.Core" />


### PR DESCRIPTION
Previously, the project file had properties that were conditional based on the build target. This caused me to infer that the project was meant to be built multiple times with different targets set as a workaround for proper multi-targeting.

This PR removes the conditions (which weren't needed anyway) and adds a comment clarifying that a single target is intended for use across all frameworks.