### PR TITLE
Fix event subscription memory leak

### DIFF
--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -1838,34 +1838,25 @@ this.oBridge.InvokeMethodAsync(this,this.oSubscriber,"WaitForEvent")
 ENDFUNC
 
 ************************************************************************
-*  OnComplete
+*  OnCompleted
 ****************************************
 ***  Function: Event Proxy that forwards the event to a function 
 ***            named On{Event} with event's parameters.
 ************************************************************************
 FUNCTION OnCompleted(lvResult, lcMethod)
-LOCAL loParams,lParamText,lCount
+LOCAL lParamText, lCount
 
-IF ISNULL(lvResult) && If the call to WaitForEvent was canceled:
+IF ISNULL(lvResult) OR VARTYPE(THIS.oHandler) != "O" && If the call to WaitForEvent was canceled or the handler was unsubscribed:
 	RETURN
 ENDIF
 
-
-loParams=CREATEOBJECT("EMPTY") && Workaround to index into array of parameters. 
 lParamText = ""
-IF NOT ISNULL(lvResult.Params)
-	lCount = 0
-	FOR EACH lParam IN lvResult.Params
-		lCount = lCount + 1
-		AddProperty(loParams,"P" + ALLTRIM(STR(lCount)),lParam)
-		lParamText = lParamText + ",loParams.P" + ALLTRIM(STR(lCount))
-	ENDFOR
-ENDIF
+FOR lCount = 0 TO lvResult.Params.Count - 1
+	lParamText = lParamText + ",lvResult.Params.Item(" + ALLTRIM(STR(lCount)) + ")"
+ENDFOR
 
-IF VARTYPE(THIS.oHandler) = "O"
-	=EVALUATE("this.oHandler." + this.oPrefix + lvResult.Name + "("+SUBSTR(lParamText,2)+")")
-	this.HandleNextEvent()
-ENDIF
+=EVALUATE("this.oHandler." + this.oPrefix + lvResult.Name + "("+SUBSTR(lParamText,2)+")")
+this.HandleNextEvent()
 
 ENDFUNC
 

--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -1846,7 +1846,8 @@ ENDFUNC
 FUNCTION OnCompleted(lvResult, lcMethod)
 LOCAL lParamText, lCount
 
-IF ISNULL(lvResult) OR VARTYPE(THIS.oHandler) != "O" && If the call to WaitForEvent was canceled or the handler was unsubscribed:
+IF VARTYPE(lvResult) != "O" OR VARTYPE(THIS.oHandler) != "O" && If the call to WaitForEvent was canceled or the handler was unsubscribed:
+	* Note that lvResult is sometimes an empty string. This is likely the result of a race condition. Fortunately, checking whether it is an object seems to be a reliable workaround.
 	RETURN
 ENDIF
 

--- a/DotnetBridge/Utilities/EventSubscriber.cs
+++ b/DotnetBridge/Utilities/EventSubscriber.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,7 +70,9 @@ namespace Westwind.WebConnection
 
         private void QueueInteropEvent(string name, object[] parameters)
         {
-            var interopEvent = new RaisedEvent { Name = name, Params = parameters };
+            var parametersArrayList = new ArrayList(parameters.Length);
+            parametersArrayList.AddRange(parameters);
+            var interopEvent = new RaisedEvent { Name = name, Params = parametersArrayList };
             if (!_completion.TrySetResult(interopEvent))
                 _raisedEvents.Enqueue(interopEvent);
         }
@@ -93,6 +96,6 @@ namespace Westwind.WebConnection
     public class RaisedEvent
     {
         public string Name { get; internal set; }
-        public object[] Params { get; internal set; }
+        public ArrayList Params { get; internal set; }
     }
 }

--- a/Tests/EventSubscriberTests.cs
+++ b/Tests/EventSubscriberTests.cs
@@ -35,9 +35,9 @@ namespace wwDotnetBridge.Tests
         static void VerifyResults(EventSubscriber subscriber)
         {
             var result = subscriber.WaitForEvent();
-            Assert.IsTrue(result.Name == nameof(Loopback.NoParams) && result.Params.Length == 0);
+            Assert.IsTrue(result.Name == nameof(Loopback.NoParams) && result.Params.Count == 0);
             result = subscriber.WaitForEvent();
-            Assert.IsTrue(result.Name == nameof(Loopback.TwoParams) && result.Params.Length == 2 && (string)result.Params[0] == "A" && (int)result.Params[1] == 1);
+            Assert.IsTrue(result.Name == nameof(Loopback.TwoParams) && result.Params.Count == 2 && (string)result.Params[0] == "A" && (int)result.Params[1] == 1);
         }
     }
 


### PR DESCRIPTION
This PR fixes an event subscription memory leak and race condition.

EventSubscriber now accounts for Dispose, QueueInteropEvent, and WaitForEvent all being called simultaneously from different threads.

EventSubscription.OnComplete contains a workaround for the likelihood that even with the concurrency improvement, there is still a race condition.

The commit for this PR is based on the commit for #35 because they involve common code. Doing so will avoid a conflict when merging.

To reproduce the leak, run a stress test that subscribes and unsubscribes to lots of instances of an object. To reproduce the bug and demonstrated the fix, only one instance needs to exist at a time, and no events need to be raised. Without the fix, as the test continues, you'll notice in Task manager FoxPro consuming more and more memory.

``` foxpro
LOCAL asyncCount
asyncCount = 0

FOR i = 1 TO 1000
	someClassWithEvents = CreateDotNetObject("SomeClassWithEvents")
	someEventHandler = CREATEOBJECT("SomeEventHandler")
	subscription = loBridge.SubscribeToEvents(someClassWithEvents, someEventHandler)
	subscription.Unsubscribe()
	loBridge.InvokeStaticMethod("System.GC", "Collect")

	asyncCount = asyncCount + 1
	IF asyncCount % 100 = 0
		? asyncCount
	ENDIF
ENDFOR

DEFINE CLASS SomeEventHandler as Custom
	FUNCTION OnSomeEvent()
	ENDFUNC
ENDDEFINE
```