### PR TITLE
Add synchronization context

### DIFF
--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -238,23 +238,9 @@ ENDFUNC
 *  SetSynchronizationContext
 ****************************************
 PROTECTED FUNCTION SetSynchronizationContext()
-LOCAL postMessageId
-postMessageId = this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
-BINDEVENT(_VFP.hWnd, postMessageId, this, "Dispatch")
+this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
 ENDFUNC
 *  SetSynchronizationContext
-
-
-************************************************************************
-*  Dispatch
-****************************************
-***  Function: Dispatches all queued send or post callbacks in the synchronization context.
-***    Return: nothing
-************************************************************************
-FUNCTION Dispatch(hWnd, nMsg, wParam, lParam) && Windows message handler signature
-this.oDotNetBridge.Dispatch()
-ENDFUNC
-*   Dispatch
 
 
 ************************************************************************

--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -26,6 +26,9 @@ SET PROCEDURE TO wwDotnetBridge ADDITIVE
 	* wwDotnetBridge.dll
 #ENDIF
 
+* Used by EventSubscription to determine which events to subscribe to.
+PUBLIC wwDotnetBridgeEventHandler
+
 
 ************************************************************************
 *  GetwwDotNetBridge
@@ -66,7 +69,6 @@ ENDFUNC
 FUNCTION InitializeDotnetVersion(lcVersion,llUseCom)
 RETURN GetwwDotnetBridge(lcVersion,llUseCom)
 ENDFUNC
-
 
 *************************************************************
 DEFINE CLASS wwDotNetBridge AS Custom
@@ -224,11 +226,36 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 
 	this.oDotNetBridge.LoadAssembly("System")		
 	this.oDotNetBridge.IsThrowOnErrorEnabled = this.lThrowOnError
+	this.SetSynchronizationContext()
 ENDIF
 
 RETURN this.oDotNetBridge
 ENDFUNC
 *   CreateDotNetBridge
+
+
+************************************************************************
+*  SetSynchronizationContext
+****************************************
+PROTECTED FUNCTION SetSynchronizationContext()
+LOCAL postMessageId
+postMessageId = this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
+BINDEVENT(_VFP.hWnd, postMessageId, this, "Dispatch")
+ENDFUNC
+*  SetSynchronizationContext
+
+
+************************************************************************
+*  Dispatch
+****************************************
+***  Function: Dispatches all queued send or post callbacks in the synchronization context.
+***    Return: nothing
+************************************************************************
+FUNCTION Dispatch(hWnd, nMsg, wParam, lParam) && Windows message handler signature
+this.oDotNetBridge.Dispatch()
+ENDFUNC
+*   Dispatch
+
 
 ************************************************************************
 *  SetClrVersion
@@ -479,6 +506,66 @@ ENDIF
 RETURN loResult
 ENDFUNC
 *   InvokeMethod
+
+
+************************************************************************
+*  PostMethod
+****************************************
+***  Function: Posts a .NET instance method to the FoxPro message queue. Useful to avoid reentrancy in event handlers.
+***    Return: nothing
+************************************************************************
+FUNCTION PostMethod(loObject, lcMethod, lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,;
+                                                  lvParm6, lvParm7, lvParm8, lvParm9, lvParm10)
+TRY
+	this.oDotNetBridge.PostInvokedMethods = .T.
+	this.SetError()
+
+	LOCAL loBridge, lnParms
+	loBridge = this.oDotNetBridge
+	lnParms = PCOUNT()
+	DO CASE
+		CASE lnParms = 2
+		  loBridge.InvokeMethod(loObject, lcMethod)
+		CASE lnParms = 3
+		  loBridge.InvokeMethod_OneParm(loObject, lcMethod, lvParm1)
+		CASE lnParms = 4
+		  loBridge.InvokeMethod_TwoParms(loObject, lcMethod,lvParm1, lvParm2)
+		CASE lnParms = 5
+		  loBridge.InvokeMethod_ThreeParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3)
+		CASE lnParms = 6
+		  loBridge.InvokeMethod_FourParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4)
+		CASE lnParms = 7
+		  loBridge.InvokeMethod_FiveParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5)
+		CASE lnParms = 8
+		  loBridge.InvokeMethod_SixParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5, lvParm6)
+		CASE lnParms = 9
+		  loBridge.InvokeMethod_SevenParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5, lvParm6, lvParm7)
+		CASE lnParms = 10
+		  loBridge.InvokeMethod_EightParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5, lvParm6, lvParm7, lvParm8)
+		CASE lnParms = 11
+		  loBridge.InvokeMethod_NineParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5, lvParm6, lvParm7, lvParm8, lvParm9)
+		CASE lnParms = 12
+		  loBridge.InvokeMethod_TenParms(loObject, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5, lvParm6, lvParm7, lvParm8, lvParm9, lvParm10)	  
+
+		OTHERWISE
+      		LOCAL loArray as Westwind.WebConnection.ComArray
+			loArray = this.CreateArray("System.Object")
+
+			LOCAL lvParm
+			FOR lnX = 1 TO lnParms-2
+		   		lvParm = EVALUATE("lvParm" + TRANSFORM(lnX))
+		   		loArray.AddItem(lvParm)   	
+			ENDFOR
+	ENDCASE
+
+	IF loBridge.Error
+	   this.SetError(loBridge.ErrorMessage)
+	ENDIF   
+FINALLY
+	this.oDotNetBridge.PostInvokedMethods = .F.
+ENDTRY
+ENDFUNC
+*   PostMethod
 
 
 ************************************************************************
@@ -769,7 +856,7 @@ ENDFUNC
 ************************************************************************
 *  InvokeStaticMethod
 ****************************************
-***  Function: Calls a static .NET method with up to 5 parameters
+***  Function: Calls a static .NET method with up to 10 parameters
 ***    Assume:
 ***      Pass:
 ***    Return:
@@ -818,6 +905,57 @@ ENDIF
 RETURN loResult
 ENDFUNC
 *   InvokeStaticMethod
+
+
+************************************************************************
+*  PostStaticMethod
+****************************************
+***  Function: Posts a static .NET method with up to 10 parameters to the FoxPro message queue. Useful to avoid reentrancy in event handlers.
+***    Return: nothing
+************************************************************************
+FUNCTION PostStaticMethod(lcTypeName, lcMethod, lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,;
+                                                  lvParm6, lvParm7, lvParm8, lvParm9, lvParm10)
+TRY
+	this.oDotNetBridge.PostInvokedMethods = .T.
+	this.SetError()
+
+	LOCAL loBridge, lnParms
+	loBridge = this.oDotNetBridge
+	lnParms = PCOUNT()
+	DO CASE
+		CASE lnParms = 3
+		  loBridge.InvokeStaticMethod_OneParm(lcTypeName, lcMethod, lvParm1)
+		CASE lnParms = 4
+		  loBridge.InvokeStaticMethod_TwoParms(lcTypeName, lcMethod,lvParm1, lvParm2)
+		CASE lnParms = 5
+		  loBridge.InvokeStaticMethod_ThreeParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3)
+		CASE lnParms = 6
+		  loBridge.InvokeStaticMethod_FourParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4)
+		CASE lnParms = 7
+		  loBridge.InvokeStaticMethod_FiveParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5)
+		CASE lnParms = 8
+		  loBridge.InvokeStaticMethod_SixParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,lvParm6)
+		CASE lnParms = 9
+		  loBridge.InvokeStaticMethod_SevenParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,lvParm6, lvParm7)	
+		CASE lnParms = 10
+		  loBridge.InvokeStaticMethod_EightParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,lvParm6, lvParm7, lvParm8)	
+		CASE lnParms = 11
+		  loBridge.InvokeStaticMethod_NineParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,lvParm6, lvParm7, lvParm8, lvParm9)	
+		CASE lnParms = 12
+		  loBridge.InvokeStaticMethod_TenParms(lcTypeName, lcMethod,lvParm1, lvParm2, lvParm3, lvParm4, lvParm5,lvParm6, lvParm7, lvParm8, lvParm9, lvParm10)	
+		OTHERWISE
+		  loBridge.InvokeStaticMethod(lcTypeName, lcMethod)
+	ENDCASE
+
+	IF loBridge.Error
+	   this.SetError(loBridge.ErrorMessage)
+	ENDIF   
+FINALLY
+	this.oDotNetBridge.PostInvokedMethods = .F.
+ENDTRY
+ENDFUNC
+*   PostStaticMethod
+
 
 ************************************************************************
 *  GetStaticProperty
@@ -1154,20 +1292,23 @@ ENDFUNC
 ************************************************************************
 *  SubscribeToEvents
 ****************************************
-***  Function: Handles all events of a source object for subsequent retrieval by calling WaitForEvent.
+***  Function: Handles all events of a source object.
 ***  loSource: The object for which to subscribe to events.
-***  loHandler: An object with a method OnEvent(loEventName, loParams).
+***  loHandler: An object with handler methods corresponding to each event to subscribe to.
 ***  lcPrefix: The initial part of the event handler function for each event. Defaults to "On".
-***    Return: A subscription object. The subscription ends when this object goes out of scope.
+***  llPost: Events are posted to the synchronization context if on a background thread or if llPost is true. It is useful to set llPost to true if your event handlers call back into an event source that does not support reentrancy.
+***    Return: A subscription object. The subscription ends when it is no longer reference or when Unsubscribe() is called.
 ************************************************************************
-FUNCTION SubscribeToEvents(loSource, loHandler, lcPrefix)
+FUNCTION SubscribeToEvents(loSource, loHandler, lcPrefix, llPost)
 IF VARTYPE(lcPrefix) # "C"
 	lcPrefix = "On"
 ENDIF
-LOCAL loSubscription
-loSubscription = CREATEOBJECT("EventSubscription")
-loSubscription.Setup(this, loSource, loHandler, lcPrefix)
-RETURN loSubscription
+
+m.wwDotnetBridgeEventHandler = loHandler
+LOCAL subscription
+subscription = CREATEOBJECT("EventSubscription", this, loSource, loHandler, lcPrefix, llPost)
+m.wwDotnetBridgeEventHandler = null
+RETURN subscription
 ENDFUNC
 *   SubscribeToEvents
 
@@ -1824,17 +1965,12 @@ DEFINE CLASS EventSubscription as AsyncCallbackEvents
 *:  Author: Edward Brey  - https://github.com/breyed
 *:  Usage: Used internally by SubscribeToEvents
 ************************************************************
-HIDDEN oBridge, oHandler, oSubscriber, oPrefix
-
-oBridge = null
-oHandler = null
-oPrefix = null
-oSubscriber = null
+HIDDEN oSubscriber
 
 ************************************************************************
-*  Setup
+*  Init
 ****************************************
-***  Function: Sets up an event subscription. 
+***  Function: Initializes an event subscription. 
 ***    Assume:
 ***      Pass: loBridge   - dnb instance
 ***            loSource   - Source Object fires events
@@ -1842,62 +1978,24 @@ oSubscriber = null
 ***            lcPrefix   - prefix for event methods
 ***                         implemented on target (defaults to "On")
 ************************************************************************
-FUNCTION Setup(loBridge, loSource, loHandler, lcPrefix)
-this.oBridge = loBridge
-this.oHandler = loHandler
-this.oPrefix = lcPrefix
-Private handler
-handler = m.loHandler
-this.oSubscriber = loBridge.CreateInstance("Westwind.WebConnection.EventSubscriber", loSource, m.lcPrefix, _Vfp)
-this.HandleNextEvent()
+FUNCTION Init(loBridge, loSource, loHandler, lcPrefix, llPost)
+this.oSubscriber = loBridge.CreateInstance("Westwind.WebConnection.EventSubscriber", loSource, loHandler, lcPrefix, llPost, _VFP)
+ENDFUNC
+
+FUNCTION Destroy()
+this.Unsubscribe()
 ENDFUNC
 
 ************************************************************************
-*  UnSubscribe
+*  Unsubscribe
 ****************************************
 ***  Function: Unsubscribes events that are currently subscribed to
 ************************************************************************
-FUNCTION UnSubscribe()
-IF !ISNULL(THIS.oSubscriber)
+FUNCTION Unsubscribe()
+IF !ISNULL(this.oSubscriber)
 	this.oSubscriber.Dispose()
+	this.oSubscriber = null
 ENDIF
-ENDFUNC
- 
-  
-FUNCTION HandleNextEvent()
-this.oBridge.InvokeMethodAsync(this,this.oSubscriber,"WaitForEvent")
-ENDFUNC
-
-************************************************************************
-*  OnComplete
-****************************************
-***  Function: Event Proxy that forwards the event to a function 
-***            named On{Event} with event's parameters.
-************************************************************************
-FUNCTION OnCompleted(lvResult, lcMethod)
-LOCAL loParams,lParamText,lCount
-
-IF ISNULL(lvResult) && If the call to WaitForEvent was canceled:
-	RETURN
-ENDIF
-
-
-loParams=CREATEOBJECT("EMPTY") && Workaround to index into array of parameters. 
-lParamText = ""
-IF NOT ISNULL(lvResult.Params)
-	lCount = 0
-	FOR EACH lParam IN lvResult.Params
-		lCount = lCount + 1
-		AddProperty(loParams,"P" + ALLTRIM(STR(lCount)),lParam)
-		lParamText = lParamText + ",loParams.P" + ALLTRIM(STR(lCount))
-	ENDFOR
-ENDIF
-
-IF VARTYPE(THIS.oHandler) = "O"
-	=EVALUATE("this.oHandler." + this.oPrefix + lvResult.Name + "("+SUBSTR(lParamText,2)+")")
-	this.HandleNextEvent()
-ENDIF
-
 ENDFUNC
 
 ENDDEFINE
@@ -2034,6 +2132,7 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 
 	*this.oDotNetBridge.LoadAssembly("System")		
 	this.oDotNetBridge.IsThrowOnErrorEnabled = this.lThrowOnError
+	this.SetSynchronizationContext()
 ENDIF
 
 

--- a/Distribution/wwDotnetBridge.PRG
+++ b/Distribution/wwDotnetBridge.PRG
@@ -226,21 +226,12 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 
 	this.oDotNetBridge.LoadAssembly("System")		
 	this.oDotNetBridge.IsThrowOnErrorEnabled = this.lThrowOnError
-	this.SetSynchronizationContext()
+	this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
 ENDIF
 
 RETURN this.oDotNetBridge
 ENDFUNC
 *   CreateDotNetBridge
-
-
-************************************************************************
-*  SetSynchronizationContext
-****************************************
-PROTECTED FUNCTION SetSynchronizationContext()
-this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
-ENDFUNC
-*  SetSynchronizationContext
 
 
 ************************************************************************
@@ -2118,7 +2109,7 @@ IF VARTYPE(this.oDotNetBridge) != "O"
 
 	*this.oDotNetBridge.LoadAssembly("System")		
 	this.oDotNetBridge.IsThrowOnErrorEnabled = this.lThrowOnError
-	this.SetSynchronizationContext()
+	this.oDotNetBridge.SetSynchronizationContext(_VFP.hWnd)
 ENDIF
 
 

--- a/DotnetBridge/Utilities/EventSubscriber.cs
+++ b/DotnetBridge/Utilities/EventSubscriber.cs
@@ -1,98 +1,64 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Westwind.WebConnection
 {
     /// <summary>
-    /// FoxPro interop access to .NET events. Handles all events of a source object for subsequent retrieval by a FoxPro client.
+    /// Subscribes to all events for which a handler object has corresponding methods.
     /// </summary>
-    /// <remarks>For a FoxPro program to be notified of events, it should use `wwDotNetBridge.InvokeMethodAsync` to call <see cref="WaitForEvent"/>. When <see cref="WaitForEvent"/> asynchronously completes, the FoxPro program should handle the event it returns and then call <see cref="WaitForEvent"/> again to wait for the next event. The FoxPro class `EventSubscription`, which is returned by `SubscribeToEvents`, encapsulates this async wait loop.</remarks>
     public sealed class EventSubscriber : IDisposable
     {
-        private readonly object _source;
-        private readonly List<DelegateInfo> _eventHandlers = new List<DelegateInfo>();
-        private readonly ConcurrentQueue<RaisedEvent> _raisedEvents = new ConcurrentQueue<RaisedEvent>();
-        private TaskCompletionSource<RaisedEvent> _completion = new TaskCompletionSource<RaisedEvent>();
+        private readonly object _eventSource;
+        private readonly object _handler;
+        private readonly bool _post;
+        private readonly List<(EventInfo, Delegate)> _eventDelegates = [];
 
-        public EventSubscriber(object source, String prefix = "", dynamic vfp = null)
+        private static readonly MethodInfo invokeMethod = typeof(EventSubscriber).GetMethod(nameof(InvokeMethod), BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public EventSubscriber(object eventSource, object handler, string prefix, bool post, dynamic vfp)
         {
-            // Indicates that initially the client is not waiting.
-            _completion.SetResult(null);
+            _eventSource = eventSource;
+            _handler = handler;
+            _post = post;
+            var instanceExpression = Expression.Constant(this);
+            var handlerExpression = Expression.Constant(handler);
 
-            // For each event, adds a handler that calls QueueInteropEvent.
-            _source = source;
-            foreach (var ev in source.GetType().GetEvents())
+            foreach (var eventInfo in eventSource.GetType().GetEvents())
             {
-                // handler is a PRIVATE variable defined in EventSubscription.Setup().
-                Boolean hasMethod = vfp?.Eval($"PEMSTATUS(m.handler, '{prefix}{ev.Name}', 5)") ?? true;
+                string methodName = prefix + eventInfo.Name;
+                bool hasMethod = vfp.Eval($"PEMSTATUS(m.wwDotnetBridgeEventHandler, '{methodName}', 5)");
                 if (!hasMethod)
                     continue;
 
-                var eventParams = ev.EventHandlerType.GetMethod("Invoke").GetParameters().Select(p => Expression.Parameter(p.ParameterType)).ToArray();
-                var eventHandlerLambda = Expression.Lambda(ev.EventHandlerType,
-                    Expression.Call(
-                        instance: Expression.Constant(this),
-                        method: typeof(EventSubscriber).GetMethod(nameof(QueueInteropEvent), BindingFlags.NonPublic | BindingFlags.Instance),
-                        arg0: Expression.Constant(ev.Name),
-                        arg1: Expression.NewArrayInit(typeof(object), eventParams.Select(p => Expression.Convert(p, typeof(object))))),
-                    eventParams);
-                var eventHandler = eventHandlerLambda.Compile();
-                ev.AddEventHandler(source, eventHandler);
-                _eventHandlers.Add(new DelegateInfo(eventHandler, ev));
+                var eventHandlerType = eventInfo.EventHandlerType;
+                var paramExpressions = eventHandlerType.GetMethod("Invoke").GetParameters().Select(p => Expression.Parameter(p.ParameterType, p.Name)).ToArray();
+                var arguments = paramExpressions.Select(p => Expression.Convert(p, typeof(object))).ToArray();
+                var callExpression = Expression.Call(instanceExpression, invokeMethod, handlerExpression, Expression.Constant(methodName), Expression.NewArrayInit(typeof(object), arguments));
+                var eventDelegate = Expression.Lambda(eventHandlerType, callExpression, paramExpressions).Compile();
+                eventInfo.AddEventHandler(eventSource, eventDelegate);
+                _eventDelegates.Add((eventInfo, eventDelegate));
             }
-        }
-
-        class DelegateInfo
-        {
-            public DelegateInfo(Delegate handler, EventInfo eventInfo)
-            {
-                Delegate = handler;
-                EventInfo = eventInfo;
-            }
-
-            public Delegate Delegate { get; }
-            public EventInfo EventInfo { get; }
         }
 
         public void Dispose()
         {
-            foreach (var item in _eventHandlers)
-                item.EventInfo.RemoveEventHandler(_source, item.Delegate);
-            _completion.TrySetCanceled();
+            foreach ((var eventInfo, var eventDelegate) in _eventDelegates)
+                eventInfo.RemoveEventHandler(_eventSource, eventDelegate);
+            Marshal.FinalReleaseComObject(_handler);
         }
 
-        private void QueueInteropEvent(string name, object[] parameters)
+        private void InvokeMethod(object handler, string methodName, object[] arguments)
         {
-            var interopEvent = new RaisedEvent { Name = name, Params = parameters };
-            if (!_completion.TrySetResult(interopEvent))
-                _raisedEvents.Enqueue(interopEvent);
+            if (_post || Thread.CurrentThread != wwDotNetBridge._mainThread)
+                wwDotNetBridge._synchronizationContext.Post(_ => handler.GetType().InvokeMember(methodName, BindingFlags.InvokeMethod, null, handler, arguments), null);
+            else
+                handler.GetType().InvokeMember(methodName, BindingFlags.InvokeMethod, null, handler, arguments);
         }
-
-        /// <summary>
-        /// Waits until an event is raised, or returns immediately if a queued event is available.
-        /// </summary>
-        /// <returns>The next event, or null if this subscriber has been disposed.</returns>
-        public RaisedEvent WaitForEvent()
-        {
-            if (_raisedEvents.TryDequeue(out var interopEvent)) return interopEvent;
-            _completion = new TaskCompletionSource<RaisedEvent>();
-            var task = _completion.Task;
-            
-            task.Wait();
-
-            return task.IsCanceled ? null : task.Result;
-        }
-    }
-
-    public class RaisedEvent
-    {
-        public string Name { get; internal set; }
-        public object[] Params { get; internal set; }
     }
 }

--- a/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
+++ b/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
@@ -12,16 +12,39 @@ namespace Westwind.WebConnection
     /// <summary>
     /// Synchronizes tasks with the FoxPro main thread.
     /// </summary>
-    /// <remarks>When one or more tasks are ready to run, posts a Windows message to the main FoxPro window.</remarks>
-    internal sealed class FoxProSynchronizationContext(int hwnd, wwDotNetBridge bridge) : SynchronizationContext
+    /// <remarks>
+    /// When one or more tasks are ready to run, posts a Windows message to the main FoxPro window.
+    /// Subclasses the window to receive the posted message and dispatch the tasks.
+    /// Unlike FoxPro BINDEVENT, subclassing processes messages even when FoxPro pumps messages from a dispatched task (e.g. from a modal form).
+    /// </remarks>
+    internal sealed class FoxProSynchronizationContext : SynchronizationContext
     {
-        private readonly IntPtr _hwnd = (IntPtr)hwnd;
+        private readonly IntPtr _hwnd;
+        private readonly wwDotNetBridge _bridge;
         private readonly ConcurrentQueue<(SendOrPostCallback handler, object? state)> _postQueue = [];
+        private readonly WndProcDelegate _wndProcDelegate;
+        private readonly IntPtr _originalWndProc;
+        private readonly uint _postMessageId;
 
-        /// <summary>
-        /// Gets the ID of the Windows message posted when a task is ready to run.
-        /// </summary>
-        public int PostMessageId { get; private set; } = RegisterWindowMessage("FoxProSynchronizationContextDispatch");
+        public FoxProSynchronizationContext(int hwnd, wwDotNetBridge bridge)
+        {
+            _hwnd = (IntPtr)hwnd;
+            _bridge = bridge;
+            _wndProcDelegate = WndProc; // Prevents the delegate from being garbage collected.
+            _originalWndProc = SetWindowLongPtr(_hwnd, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(_wndProcDelegate));
+            _postMessageId = RegisterWindowMessage("FoxProSynchronizationContextDispatch");
+        }
+
+        private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (msg == _postMessageId)
+            {
+                Dispatch();
+                return IntPtr.Zero;
+            }
+
+            return CallWindowProc(_originalWndProc, hWnd, msg, wParam, lParam);
+        }
 
         /// <summary>
         /// Posts a message to indicate that there are posts ready to dispatch. Thread safe.
@@ -30,17 +53,15 @@ namespace Westwind.WebConnection
         {
             _postQueue.Enqueue((d, state));
 
-            if (!PostMessage(_hwnd, PostMessageId, IntPtr.Zero, IntPtr.Zero))
-                bridge.LastException = new OutOfMemoryException("Failed to post dispatch message.");
+            if (!PostMessage(_hwnd, _postMessageId, IntPtr.Zero, IntPtr.Zero))
+                _bridge.LastException = new OutOfMemoryException("Failed to post dispatch message.");
         }
 
         /// <summary>
-        /// Dispatches all queued send or post callbacks in the synchronization context. Called when a Windows message with ID <see cref="PostMessageId"/> is received.
+        /// Dispatches all queued send or post callbacks in the synchronization context.
         /// </summary>
-        public void Dispatch()
+        private void Dispatch()
         {
-            // FoxPro ignores a PostMessageId message when posted while handling a previous PostMessageId message. Therefore, it is important to run all queued posts.
-
             while (_postQueue.TryDequeue(out var post))
             {
                 try
@@ -49,7 +70,7 @@ namespace Westwind.WebConnection
                 }
                 catch (Exception ex)
                 {
-                    bridge.LastException = ex;
+                    _bridge.LastException = ex;
                 }
             }
         }
@@ -59,12 +80,24 @@ namespace Westwind.WebConnection
         /// </summary>
         public override void OperationStarted() => Dispatch();
 
+        private const int GWLP_WNDPROC = -4;
+
+        private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongA")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [DllImport("user32.dll")]
+        private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         [DllImport("user32.dll", CharSet = CharSet.Unicode, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        private static extern int RegisterWindowMessage(string lpString);
+        private static extern uint RegisterWindowMessage(string lpString);
 
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         [DllImport("user32.dll", SetLastError = true)]
-        private static extern bool PostMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+        private static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
+++ b/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Westwind.WebConnection
+{
+    /// <summary>
+    /// Synchronizes tasks with the FoxPro main thread.
+    /// </summary>
+    /// <remarks>When one or more tasks are ready to run, posts a Windows message to the main FoxPro window.</remarks>
+    internal sealed class FoxProSynchronizationContext(int hwnd, wwDotNetBridge bridge) : SynchronizationContext
+    {
+        private readonly IntPtr _hwnd = (IntPtr)hwnd;
+        private readonly ConcurrentQueue<(SendOrPostCallback handler, object? state)> _postQueue = [];
+
+        /// <summary>
+        /// Gets the ID of the Windows message posted when a task is ready to run.
+        /// </summary>
+        public int PostMessageId { get; private set; } = RegisterWindowMessage("FoxProSynchronizationContextDispatch");
+
+        /// <summary>
+        /// Posts a message to indicate that there are posts ready to dispatch. Thread safe.
+        /// </summary>
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            _postQueue.Enqueue((d, state));
+
+            if (!PostMessage(_hwnd, PostMessageId, IntPtr.Zero, IntPtr.Zero))
+                bridge.LastException = new OutOfMemoryException("Failed to post dispatch message.");
+        }
+
+        /// <summary>
+        /// Dispatches all queued send or post callbacks in the synchronization context. Called when a Windows message with ID <see cref="PostMessageId"/> is received.
+        /// </summary>
+        public void Dispatch()
+        {
+            // FoxPro ignores a PostMessageId message when posted while handling a previous PostMessageId message. Therefore, it is important to run all queued posts.
+
+            while (_postQueue.TryDequeue(out var post))
+            {
+                try
+                {
+                    post.handler(post.state);
+                }
+                catch (Exception ex)
+                {
+                    bridge.LastException = ex;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts a dispatch operation. Used by external code to dispatch queued callbacks.
+        /// </summary>
+        public override void OperationStarted() => Dispatch();
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        private static extern int RegisterWindowMessage(string lpString);
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+    }
+}

--- a/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
+++ b/DotnetBridge/Utilities/FoxProSynchronizationContext.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,16 +21,14 @@ namespace Westwind.WebConnection
     internal sealed class FoxProSynchronizationContext : SynchronizationContext
     {
         private readonly IntPtr _hwnd;
-        private readonly wwDotNetBridge _bridge;
         private readonly ConcurrentQueue<(SendOrPostCallback handler, object? state)> _postQueue = [];
         private readonly WndProcDelegate _wndProcDelegate;
         private readonly IntPtr _originalWndProc;
         private readonly uint _postMessageId;
 
-        public FoxProSynchronizationContext(int hwnd, wwDotNetBridge bridge)
+        public FoxProSynchronizationContext(int hwnd)
         {
             _hwnd = (IntPtr)hwnd;
-            _bridge = bridge;
             _wndProcDelegate = WndProc; // Prevents the delegate from being garbage collected.
             _originalWndProc = SetWindowLongPtr(_hwnd, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(_wndProcDelegate));
             _postMessageId = RegisterWindowMessage("FoxProSynchronizationContextDispatch");
@@ -54,7 +53,7 @@ namespace Westwind.WebConnection
             _postQueue.Enqueue((d, state));
 
             if (!PostMessage(_hwnd, _postMessageId, IntPtr.Zero, IntPtr.Zero))
-                _bridge.LastException = new OutOfMemoryException("Failed to post dispatch message.");
+                throw new OutOfMemoryException("Failed to post dispatch message.");
         }
 
         /// <summary>
@@ -70,7 +69,10 @@ namespace Westwind.WebConnection
                 }
                 catch (Exception ex)
                 {
-                    _bridge.LastException = ex;
+                    // Reports the unhandled exception as an unobserved task exception.
+                    // An event is raised by TaskScheduler.UnobservedTaskException after the task's finalizer runs.
+                    var edi = ExceptionDispatchInfo.Capture(ex);
+                    Task.Run(() => edi.Throw());
                 }
             }
         }

--- a/DotnetBridge/wwDotNetBridge.cs
+++ b/DotnetBridge/wwDotNetBridge.cs
@@ -129,15 +129,11 @@ namespace Westwind.WebConnection
         /// <summary>
         /// Sets the current synchronization context to use the FoxPro main thread.
         /// </summary>
-        /// <returns>The ID of the Windows message posted when a task is ready to run.</returns>
-        public int SetSynchronizationContext(int hwnd)
+        public void SetSynchronizationContext(int hwnd)
         {
             _synchronizationContext = new FoxProSynchronizationContext(hwnd, this);
             SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
-            return _synchronizationContext.PostMessageId;
         }
-
-        public void Dispatch() => _synchronizationContext.Dispatch();
 
         #region LoadAssembly Routines
 

--- a/DotnetBridge/wwDotNetBridge.cs
+++ b/DotnetBridge/wwDotNetBridge.cs
@@ -131,7 +131,7 @@ namespace Westwind.WebConnection
         /// </summary>
         public void SetSynchronizationContext(int hwnd)
         {
-            _synchronizationContext = new FoxProSynchronizationContext(hwnd, this);
+            _synchronizationContext = new FoxProSynchronizationContext(hwnd);
             SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
         }
 

--- a/DotnetBridge/wwDotNetBridge.csproj
+++ b/DotnetBridge/wwDotNetBridge.csproj
@@ -32,6 +32,7 @@
 		<RepositoryUrl>https://github.com/RickStrahl/wwDotnetBridge</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>latest</LangVersion>
 		<NoWarn>$(NoWarn);CS1591;CS1572;CS1573</NoWarn>		
 	</PropertyGroup>
 

--- a/Tests/wwDotnetBridge.Tests.csproj
+++ b/Tests/wwDotnetBridge.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Westwind.WebConnection.Tests</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Supports posting methods to the synchronization context to be dispatched from the message loop on the main thread.
* Events are forwarded directly to the handler, except that events from background threads or configured to post are posted to the synchronization context.
* When a task method completes, the status is posted on the synchronization context.
* C# async/await uses the synchronization context by default, causing continuations to run on the main thread. .NET code that can run safely on a background thread can opt to do so with `ConfigureAwait(false)`.

This commit eliminates background thread calls into FoxPro and C# continuations, avoiding race conditions and data tearing, and providing a deterministic runtime environment.